### PR TITLE
Add `deployment.env` validation

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -1,4 +1,4 @@
-const envSchema = require('./env');
+const {EnvObject} = require('./env');
 const staticSchema = require('./config-static');
 
 module.exports = {
@@ -15,12 +15,12 @@ module.exports = {
 				'array'
 			]
 		},
-		'env': envSchema,
+		'env': EnvObject,
 		'build': {
 			type: 'object',
 			additionalProperties: false,
 			properties: {
-				env: envSchema
+				env: EnvObject
 			}
 		},
 		'scale': {

--- a/deployment/env.js
+++ b/deployment/env.js
@@ -1,18 +1,61 @@
+const maxEnvLength = 100;
+
+/* TODO: figure out how to make these blacklisted for `EnvKey`
+const reservedEnvKeys = [
+	'NOW',
+	'NOW_REGION',
+	'NOW_DC',
+	'NOW_URL',
+
+	// Questionable?
+	'PATH',
+	'HOME',
+	'TEMP',
+
+	// Legacy
+	'NOW_PLAN',
+	'AUTH_TOKEN',
+	'DEPLOYMENT_ID',
+	'REGISTRY_AUTH_TOKEN'
+];
+*/
+
+const EnvKey = {
+	type: 'string',
+	pattern: '^[A-z0-9_]+$',
+	minLength: 1,
+	maxLength: 256
+};
+
+const EnvKeys = {
+	type: 'array',
+	minItems: 0,
+	maxItems: maxEnvLength,
+	uniqueItems: true,
+	items: EnvKey,
+	additionalProperties: false
+};
+
+const EnvValue = {
+	type: 'string',
+	minLength: 0,
+	maxLength: 65536
+};
+
+// { 'FOO': 'BAR' }
+const EnvObject = {
+	type: 'object',
+	minProperties: 0,
+	maxProperties: maxEnvLength,
+	patternProperties: {
+		'.+': EnvValue
+	},
+	additionalProperties: false
+};
+
 module.exports = {
-	anyOf: [
-		{
-			type: 'object',
-			patternProperties: {
-				'.+': {
-					type: 'string'
-				}
-			}
-		},
-		{
-			type: 'array',
-			items: {
-				type: 'string'
-			}
-		}
-	]
+	EnvKey,
+	EnvKeys,
+	EnvValue,
+	EnvObject
 };

--- a/deployment/env.js
+++ b/deployment/env.js
@@ -1,6 +1,5 @@
 const maxEnvLength = 100;
 
-/* TODO: figure out how to make these blacklisted for `EnvKey`
 const reservedEnvKeys = [
 	'NOW',
 	'NOW_REGION',
@@ -18,13 +17,15 @@ const reservedEnvKeys = [
 	'DEPLOYMENT_ID',
 	'REGISTRY_AUTH_TOKEN'
 ];
-*/
 
 const EnvKey = {
 	type: 'string',
 	pattern: '^[A-z0-9_]+$',
 	minLength: 1,
-	maxLength: 256
+	maxLength: 256,
+	not: {
+		'enum': reservedEnvKeys
+	}
 };
 
 const EnvKeys = {

--- a/test/deployment-env.js
+++ b/test/deployment-env.js
@@ -88,10 +88,10 @@ exports.test_env_object_bad_type = () => {
 	assert.equal(ajv.errors[0].keyword, 'type');
 };
 
-exports.test_env_object_bad_type = () => {
+exports.test_env_object_too_long = () => {
 	const isValid = ajv.validate(EnvObject, {
-		FOO: true
+		FOO: 'a'.repeat(70000)
 	});
 	assert.equal(isValid, false);
-	assert.equal(ajv.errors[0].keyword, 'type');
+	assert.equal(ajv.errors[0].keyword, 'maxLength');
 };

--- a/test/deployment-env.js
+++ b/test/deployment-env.js
@@ -62,6 +62,15 @@ exports.test_env_keys_non_unique = () => {
 	assert.equal(ajv.errors[0].keyword, 'uniqueItems');
 };
 
+exports.test_env_keys_reserved = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		'NOW'
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'not');
+};
+
 // EnvObject
 exports.test_env_object_valid = () => {
 	const isValid = ajv.validate(EnvObject, {
@@ -69,6 +78,14 @@ exports.test_env_object_valid = () => {
 		BAZ: '@secret'
 	});
 	assert.equal(isValid, true);
+};
+
+exports.test_env_object_bad_type = () => {
+	const isValid = ajv.validate(EnvObject, {
+		FOO: true
+	});
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'type');
 };
 
 exports.test_env_object_bad_type = () => {

--- a/test/deployment-env.js
+++ b/test/deployment-env.js
@@ -1,0 +1,80 @@
+/* eslint camelcase: 0 */
+const AJV = require('ajv');
+const assert = require('assert');
+const {
+	EnvKeys,
+	EnvObject
+} = require('../deployment/env');
+
+const ajv = new AJV({allErrors: true});
+
+// EnvKeys
+exports.test_env_keys_valid = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		'BAR'
+	]);
+	assert.equal(isValid, true);
+};
+
+exports.test_env_keys_too_short = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		''
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'minLength');
+};
+
+exports.test_env_keys_too_long = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		'A'.repeat(257)
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'maxLength');
+};
+
+exports.test_env_keys_invalid_chars = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		'BA,D'
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'pattern');
+};
+
+exports.test_env_keys_invalid_type = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		true
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'type');
+};
+
+exports.test_env_keys_non_unique = () => {
+	const isValid = ajv.validate(EnvKeys, [
+		'FOO',
+		'FOO'
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'uniqueItems');
+};
+
+// EnvObject
+exports.test_env_object_valid = () => {
+	const isValid = ajv.validate(EnvObject, {
+		FOO: 'BAR',
+		BAZ: '@secret'
+	});
+	assert.equal(isValid, true);
+};
+
+exports.test_env_object_bad_type = () => {
+	const isValid = ajv.validate(EnvObject, {
+		FOO: true
+	});
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'type');
+};

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -77,20 +77,11 @@ exports.test_invalid_env_types = () => {
 };
 
 exports.test_valid_build_env_types = () => {
-	let isValid = ajv.validate(deploymentConfigSchema, {
+	const isValid = ajv.validate(deploymentConfigSchema, {
 		build: {
 			env: {
 				VALID: '1'
 			}
-		}
-	});
-	assert.equal(isValid, true);
-
-	isValid = ajv.validate(deploymentConfigSchema, {
-		build: {
-			env: [
-				'USER_SUPPLIED_ENV'
-			]
 		}
 	});
 	assert.equal(isValid, true);


### PR DESCRIPTION
The `EnvKeys` and `EnvObject` schemas are the high-level ones.

Note that the consumer will have to validate `EnvKeys` against the `Object.keys(env)` since there does not appear to be a way to "type" the keys of the object in the `EnvObject` schema.