### PR TITLE
Blacklist all `NOW_*` env vars for deployments

### DIFF
--- a/deployment/env.js
+++ b/deployment/env.js
@@ -2,9 +2,6 @@ const maxEnvLength = 100;
 
 const reservedEnvKeys = [
 	'NOW',
-	'NOW_REGION',
-	'NOW_DC',
-	'NOW_URL',
 
 	// Questionable?
 	'PATH',
@@ -12,7 +9,6 @@ const reservedEnvKeys = [
 	'TEMP',
 
 	// Legacy
-	'NOW_PLAN',
 	'AUTH_TOKEN',
 	'DEPLOYMENT_ID',
 	'REGISTRY_AUTH_TOKEN'
@@ -23,9 +19,18 @@ const EnvKey = {
 	pattern: '^[A-z0-9_]+$',
 	minLength: 1,
 	maxLength: 256,
-	not: {
-		'enum': reservedEnvKeys
-	}
+	allOf: [
+		{
+			not: {
+				'enum': reservedEnvKeys
+			}
+		},
+		{
+			not: {
+				pattern: '^NOW_.*$'
+			}
+		}
+	]
 };
 
 const EnvKeys = {

--- a/test/deployment-env.js
+++ b/test/deployment-env.js
@@ -63,9 +63,27 @@ exports.test_env_keys_non_unique = () => {
 };
 
 exports.test_env_keys_reserved = () => {
-	const isValid = ajv.validate(EnvKeys, [
+	let isValid = ajv.validate(EnvKeys, [
 		'FOO',
 		'NOW'
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'not');
+
+	isValid = ajv.validate(EnvKeys, [
+		'NOW_DC'
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'not');
+
+	isValid = ajv.validate(EnvKeys, [
+		'NOW_FOO'
+	]);
+	assert.equal(isValid, false);
+	assert.equal(ajv.errors[0].keyword, 'not');
+
+	isValid = ajv.validate(EnvKeys, [
+		'AUTH_TOKEN'
 	]);
 	assert.equal(isValid, false);
 	assert.equal(ajv.errors[0].keyword, 'not');


### PR DESCRIPTION
`NOW_*` is our Now platform "namespace" for env vars, and reserving
all of it instead of just specific keys is more future-proof.