### PR TITLE
Support github.enabled in now.json

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -122,6 +122,15 @@ module.exports = {
 				}
 			}
 		},
+		'github': {
+			type: 'object',
+			properties: {
+				enabled: {
+					type: 'boolean'
+				}
+			},
+			additionalProperties: false
+		},
 		'slot': {
 			type: 'string',
 			pattern: 'c.125-m512|staging-*'

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -225,3 +225,21 @@ exports.test_valid_static_object_invalid_prop = () => {
 	});
 	assert.equal(isValid, false);
 };
+
+exports.test_github_enabled = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		github: {
+			enabled: false
+		}
+	});
+	assert.equal(isValid, true);
+};
+
+exports.test_github_additional_field = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		github: {
+			abc: 'bbc'
+		}
+	});
+	assert.equal(isValid, false);
+};


### PR DESCRIPTION
This is required to use with PR: https://github.com/zeit/github-webhook-worker/issues/74
Otherwise `now-cli` throw an error when we trying to deploy the app locally.