### PR TITLE
Remove hard-coding the DC names for `scale` validation

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -43,7 +43,7 @@ module.exports = {
 		'scale': {
 			type: 'object',
 			patternProperties: {
-				'^(sfo|bru|gru|iad)1$': {
+				'.+': {
 					type: 'object',
 					required: ['max', 'min'],
 					properties: {

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -252,3 +252,39 @@ exports.test_github_additional_field = () => {
 	});
 	assert.equal(isValid, false);
 };
+
+exports.test_scale_sfo1 = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		scale: {
+			sfo1: {
+				min: 0,
+				max: 1
+			}
+		}
+	});
+	assert.equal(isValid, true);
+};
+
+exports.test_scale_all = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		scale: {
+			all: {
+				min: 0,
+				max: 'auto'
+			}
+		}
+	});
+	assert.equal(isValid, true);
+};
+
+exports.test_scale_invalid = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		scale: {
+			foo: {
+				min: -1,
+				max: 'auto'
+			}
+		}
+	});
+	assert.equal(isValid, false);
+};


### PR DESCRIPTION
Instead, the server-side is expected to use `@zeit/now-dc-discovery`
to dynamically validate the DC names after validating the schema.

This paves the way for accepting "all" region on the server-side.