### PR TITLE
Add github.autoAlias flag to now.json

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -130,6 +130,9 @@ module.exports = {
 				},
 				aliasing: {
 					type: 'boolean'
+				},
+				autoAlias: {
+					type: 'boolean'
 				}
 			},
 			additionalProperties: false

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -244,6 +244,15 @@ exports.test_github_aliasing = () => {
 	assert.equal(isValid, true);
 };
 
+exports.test_github_auto_alias = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		github: {
+			autoAlias: false
+		}
+	});
+	assert.equal(isValid, true);
+};
+
 exports.test_github_additional_field = () => {
 	const isValid = ajv.validate(deploymentConfigSchema, {
 		github: {


### PR DESCRIPTION
This flag will stop aliasing automatically on the default branch.