### PR TITLE
Remove support for github.aliasing

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -128,9 +128,6 @@ module.exports = {
 				enabled: {
 					type: 'boolean'
 				},
-				aliasing: {
-					type: 'boolean'
-				},
 				autoAlias: {
 					type: 'boolean'
 				}

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -235,15 +235,6 @@ exports.test_github_enabled = () => {
 	assert.equal(isValid, true);
 };
 
-exports.test_github_aliasing = () => {
-	const isValid = ajv.validate(deploymentConfigSchema, {
-		github: {
-			aliasing: false
-		}
-	});
-	assert.equal(isValid, true);
-};
-
 exports.test_github_auto_alias = () => {
 	const isValid = ajv.validate(deploymentConfigSchema, {
 		github: {


### PR DESCRIPTION
We don't need this since we've `github.autoAlias`.