### PR TITLE
Add `service.port` to deployment schema

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -1,6 +1,18 @@
 const {EnvKeys, EnvObject} = require('./config-env');
 const staticSchema = require('./config-static');
 
+const serviceSchema = {
+	type: 'object',
+	additionalProperties: false,
+	properties: {
+		port: {
+			type: 'number',
+			minimum: 1,
+			maximum: 65535
+		}
+	}
+};
+
 module.exports = {
 	type: 'object',
 	additionalProperties: false,
@@ -137,6 +149,7 @@ module.exports = {
 		'slot': {
 			type: 'string',
 			pattern: 'c.125-m512|c1-m4096|staging-*'
-		}
+		},
+		'service': serviceSchema
 	}
 };

--- a/deployment/config.js
+++ b/deployment/config.js
@@ -1,17 +1,6 @@
+const {Service} = require('./service');
 const {EnvKeys, EnvObject} = require('./config-env');
 const staticSchema = require('./config-static');
-
-const serviceSchema = {
-	type: 'object',
-	additionalProperties: false,
-	properties: {
-		port: {
-			type: 'number',
-			minimum: 1,
-			maximum: 65535
-		}
-	}
-};
 
 module.exports = {
 	type: 'object',
@@ -150,6 +139,6 @@ module.exports = {
 			type: 'string',
 			pattern: 'c.125-m512|c1-m4096|staging-*'
 		},
-		'service': serviceSchema
+		'service': Service
 	}
 };

--- a/deployment/service.js
+++ b/deployment/service.js
@@ -5,7 +5,7 @@ const Service = {
 		port: {
 			type: 'number',
 			minimum: 1,
-			maximum: 65535
+			maximum: 32767
 		}
 	}
 };

--- a/deployment/service.js
+++ b/deployment/service.js
@@ -1,0 +1,15 @@
+const Service = {
+	type: 'object',
+	additionalProperties: false,
+	properties: {
+		port: {
+			type: 'number',
+			minimum: 1,
+			maximum: 65535
+		}
+	}
+};
+
+module.exports = {
+	Service
+};

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -288,3 +288,37 @@ exports.test_scale_invalid = () => {
 	});
 	assert.equal(isValid, false);
 };
+
+exports.test_service_invalid = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		service: 'foo'
+	});
+	assert.equal(isValid, false);
+};
+
+exports.test_service_port_valid = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		service: {
+			port: 80
+		}
+	});
+	assert.equal(isValid, true);
+};
+
+exports.test_service_port_invalid = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		service: {
+			port: 0
+		}
+	});
+	assert.equal(isValid, false);
+};
+
+exports.test_service_port_invalid_type = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		service: {
+			port: '3000'
+		}
+	});
+	assert.equal(isValid, false);
+};


### PR DESCRIPTION
Will be used to specify an explicit port that the application
is bound to, and the proxy will forward requests to.