### PR TITLE
Add support for the project field

### DIFF
--- a/deployment/config.js
+++ b/deployment/config.js
@@ -27,6 +27,10 @@ module.exports = {
 			type: 'string',
 			minLength: 1
 		},
+		'project': {
+			type: 'string',
+			minLength: 1
+		},
 		'alias': {
 			type: [
 				'string',

--- a/test/deployment.js
+++ b/test/deployment.js
@@ -226,6 +226,13 @@ exports.test_valid_static_object_invalid_prop = () => {
 	assert.equal(isValid, false);
 };
 
+exports.test_project = () => {
+	const isValid = ajv.validate(deploymentConfigSchema, {
+		project: 'cool-project'
+	});
+	assert.equal(isValid, true);
+};
+
 exports.test_github_enabled = () => {
 	const isValid = ajv.validate(deploymentConfigSchema, {
 		github: {


### PR DESCRIPTION
This will allow us to use `project` field in `now.json` for v1 deployments.