### PR TITLE
Added auth config options to config-static

### DIFF
--- a/deployment/config-static.js
+++ b/deployment/config-static.js
@@ -73,6 +73,9 @@ module.exports = {
 		},
 		'renderSingle': {
 			type: 'boolean'
+		},
+		'auth': {
+			type: 'array'
 		}
 	},
 	additionalProperties: false


### PR DESCRIPTION
This PR is in support of https://github.com/zeit/serve-handler/pull/96, which requires an additional field for `auth` in the static config. As mentioned in that PR, this structure is super simple, just `[ "username", "password" ]` for configuration. I'm happy to change this as needed to support the feature.